### PR TITLE
resuse socket to avoid binding errors (Address already in use)

### DIFF
--- a/socklib.c
+++ b/socklib.c
@@ -351,8 +351,14 @@ int setSocketToBroadcast(int sock) {
     return setsockopt(sock, SOL_SOCKET, SO_BROADCAST, (char *)&p, sizeof(int));
 }
 
+int setSocketReuseAddress(int sock) {
+    /* set the socket option to reuse address with bind() */
+    int p = 1;
+    return setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char *)&p, sizeof(int));
+}
+
 int setTtl(int sock, int ttl) {
-    /* set the socket to broadcast */
+    /* set the ttl value for the socket */
     return setsockopt(sock, SOL_IP, IP_MULTICAST_TTL, (char*)&ttl, sizeof(int));
 }
 
@@ -934,6 +940,9 @@ int makeSocket(addr_type_t addr_type,
       closesocket(s);
       return -1;
     }
+    ret = setSocketReuseAddress(s);
+    if(ret < 0)
+        udpc_fatal(1, "Failed to set socket option to reuse address");
     ret = bind(s, (struct sockaddr *) &myaddr, sizeof(myaddr));
     if (ret < 0) {
         char buffer[16];

--- a/socklib.h
+++ b/socklib.h
@@ -143,6 +143,7 @@ int makeSocket(addr_type_t addr_type, net_if_t *net_if,
                struct sockaddr_in *tmpl, int port);
 
 int setSocketToBroadcast(int sock);
+int setSocketReuseAddress(int sock);
 int setTtl(int sock, int ttl);
 
 int setMcastDestination(int,net_if_t *,struct sockaddr_in *);


### PR DESCRIPTION
resuse socket to avoid binding errors (Address already in use)
related to tomswartz07/udpcast ae07a2a940136660b0e3a4cdef0d4466b060046a